### PR TITLE
Fix UTF-8 output and date formatting

### DIFF
--- a/userdata.php
+++ b/userdata.php
@@ -1,4 +1,5 @@
 <?php
+header('Content-Type: text/html; charset=UTF-8');
 $serverName = getenv('SQLSRV_SERVER') ?: '127.0.0.1';
 $connectionOptions = [
     "Database" => getenv('SQLSRV_DATABASE') ?: 'ICCLdb',
@@ -23,6 +24,8 @@ if ($stmt === false) {
     die('Query failed.');
 }
 
+echo "<!DOCTYPE html>\n";
+echo "<html><head><meta charset='UTF-8'></head><body>\n";
 echo "<table border='1'>\n";
 while ($row = sqlsrv_fetch_array($stmt, SQLSRV_FETCH_ASSOC)) {
     echo "<tr>";
@@ -35,6 +38,7 @@ while ($row = sqlsrv_fetch_array($stmt, SQLSRV_FETCH_ASSOC)) {
     echo "</tr>\n";
 }
 echo "</table>\n";
+echo "</body></html>\n";
 
 sqlsrv_free_stmt($stmt);
 sqlsrv_close($conn);


### PR DESCRIPTION
## Summary
- ensure UTF-8 headers are sent before output
- wrap table in a basic HTML skeleton

## Testing
- `php -l userdata.php`

------
https://chatgpt.com/codex/tasks/task_e_6886ec88251c8322b21579d7fefa967c